### PR TITLE
Adding var_path to be consistent with browserid/bigtent

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,10 +44,10 @@ var conf = module.exports = convict({
     format: "string",
     env: "PRIV_KEY_PATH"
   },
-  log_path: {
-    doc: "Where logs output will be written",
+  var_path: {
+    doc: "Deployment specific files will be read and written, should have a log directory",
     format: "string?",
-    env: "LOG_PATH"
+    env: "VAR_PATH"
   },
   certificate_validity_ms: {
     doc: "Default certificate validity in milliseconds",

--- a/lib/logging-config.js
+++ b/lib/logging-config.js
@@ -1,11 +1,31 @@
-var winston = require('winston'),
-     config = require('./config.js');
+var config = require('./config.js'),
+    fs = require('fs'),
+    path = require('path'),
+    winston = require('winston');
 
 // for test environments, remove the Console logging
 if (process.env.NODE_ENV === 'test') {
   winston.remove(winston.transports.Console);
 }
 
-if (config.has('log_path')) {
-  winston.add(winston.transports.File, { filename: config.get('log_path')});
-} 
+if (config.has('var_path')) {
+  var logDir = path.join(config.get('var_path'), 'log');
+
+  // simple inline function for creation of dirs
+  function mkdir_p(p) {
+    if (!fs.existsSync(p)) {
+      mkdir_p(path.dirname(p));
+      fs.mkdirSync(p, "0755");
+    }
+  }
+
+  mkdir_p(logDir);
+
+  var logfile = path.join(logDir, 'certifier.log');
+  winston.add(winston.transports.File, {
+    timestamp: function() { return new Date().toISOString(); },
+    filename: logfile,
+    colorize: true,
+    handleExceptions: !!process.env.LOG_TO_CONSOLE
+  });
+}

--- a/scripts/browserid-certifier.spec
+++ b/scripts/browserid-certifier.spec
@@ -2,7 +2,7 @@
 
 Name:          browserid-certifier
 Version:       0.2013.02.14
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       BrowserID Certifier
 Packager:      Pete Fritchman <petef@mozilla.com>
 Group:         Development/Libraries


### PR DESCRIPTION
Make logging more consistent with browserid.

/cc @gene1wood 
