### PR TITLE
Only listen locally by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,19 @@ You must install the dependencies:
 You must create a config file. Example ``config/local.json``
 
     {
-      "ip": "0.0.0.0",
-      "issuer_hostname": "dev.bigtent.mozilla.org",
+      "ip": "127.0.0.1",
       "port": 8080,
+      "issuer_hostname": "dev.bigtent.mozilla.org",
       "pub_key_path": "var/key.publickey",
       "priv_key_path": "var/key.secretkey"
     }
+
+For maximum security, the above configuration makes the server
+only listen locally (on 127.0.0.1).
+
+If you need the certifier to be accessible over the network,
+consider changing to something else,
+or listen on every IP (with "0.0.0.0"), provided you protect it by other means.
 
 Generating the Keypar
 ---------------------

--- a/config/local.json-dist
+++ b/config/local.json-dist
@@ -1,7 +1,7 @@
 {
-  "ip": "0.0.0.0",
-  "issuer_hostname": "dev.bigtent.mozilla.org",
+  "ip": "127.0.0.1",
   "port": 8080,
+  "issuer_hostname": "dev.bigtent.mozilla.org",
   "pub_key_path": "var/key.publickey",
   "priv_key_path": "var/key.secretkey"
 }


### PR DESCRIPTION
Listening on all interfaces by default and not mentioning it
at all may leave some people use that default and expose
their certifiers publicly.

This makes it use a safer default and mentions it explicitly.

The ip/port declarations in the sample config were also moved
closer together.
